### PR TITLE
Link to dashboard rather than map

### DIFF
--- a/_data/species.csv
+++ b/_data/species.csv
@@ -63,10 +63,10 @@ speciesKey,species,occurrenceCount,vernacularNameEn,vernacularNameEs,imageSrc,im
 4287132,Acipenser oxyrinchus,36272,Atlantic Sturgeon,,https://inaturalist-open-data.s3.amazonaws.com/photos/158152739/medium.jpg,https://www.inaturalist.org/observations/95278061,,Bony fish,VU
 2433467,Phocarctos hookeri,33285,New Zealand Sea Lion,,,,,Marine mammals,EN
 2392280,Acanthopagrus australis,31735,Yellowfin Bream,,,,,Bony fish,LC
-2481381,Phoebastria immutabilis,28882,Laysan Albatross,,,,,Birds,NT
+2481381,Phoebastria immutabilis,28882,Laysan Albatross,,https://inaturalist-open-data.s3.amazonaws.com/photos/625951608/medium.jpg,https://www.inaturalist.org/observations/343606478,Howard Thiele,Birds,NT
 5209329,Macquaria novemaculeata,27968,Australian Bass,,,,,Bony fish,LC
 2412740,Alosa pseudoharengus,27863,Alewife,,https://inaturalist-open-data.s3.amazonaws.com/photos/107690224/medium.jpg,https://www.inaturalist.org/observations/66757912,,Bony fish,LC
-2480967,Sula dactylatra,26686,Masked Booby,,,,,Birds,LC
+2480967,Sula dactylatra,26686,Masked Booby,,https://inaturalist-open-data.s3.amazonaws.com/photos/251807897/medium.jpeg,https://www.inaturalist.org/observations/146460958,Nick Leggatt,Birds,LC
 8351946,Clupea harengus,25785,Atlantic Herring,,https://inaturalist-open-data.s3.amazonaws.com/photos/370025857/medium.jpg,https://www.inaturalist.org/observations/209104292,,Bony fish,LC
 2417541,Orectolobus maculatus,25565,Spotted Wobbegong,,,,,Sharks & Rays,LC
 2390185,Siganus rivulatus,25521,Rivulated Rabbitfish,,https://inaturalist-open-data.s3.amazonaws.com/photos/430342190/medium.jpg,https://www.inaturalist.org/observations/241461222,Pauline Rico,Bony fish,LC
@@ -79,7 +79,7 @@ speciesKey,species,occurrenceCount,vernacularNameEn,vernacularNameEs,imageSrc,im
 2417970,Carcharhinus limbatus,20508,Common Blacktip Shark,,https://inaturalist-open-data.s3.amazonaws.com/photos/225162527/medium.jpg,https://www.inaturalist.org/observations/132236117,Simon Pierce,Sharks & Rays,VU
 8231523,Sillago ciliata,20409,Sand Whiting,,,,,Bony fish,LC
 2433474,Arctocephalus forsteri,20198,Long-nosed Fur Seal,,,,,Marine mammals,LC
-9743996,Phaethon aethereus,20112,Red-billed Tropicbird,,,,,Birds,LC
+9743996,Phaethon aethereus,20112,Red-billed Tropicbird,,https://inaturalist-open-data.s3.amazonaws.com/photos/328451776/medium.jpg,https://www.inaturalist.org/observations/187769613,Gerold Morrison,Birds,LC
 2374885,Lethrinus nebulosus,19859,Spangled Emperor,,https://inaturalist-open-data.s3.amazonaws.com/photos/287497294/medium.jpg,https://www.inaturalist.org/observations/166044553,Bruce Deagle,Bony fish,LC
 2397850,Xiphias gladius,19763,Broadbill Swordfish,,,,,Bony fish,NT
 2383158,Achoerodus gouldii,18566,Western Blue Groper,,,,,Bony fish,VU
@@ -87,17 +87,17 @@ speciesKey,species,occurrenceCount,vernacularNameEn,vernacularNameEs,imageSrc,im
 5863764,Metacarcinus magister,17881,Dungeness Crab,,https://inaturalist-open-data.s3.amazonaws.com/photos/63867685/medium.jpeg,https://www.inaturalist.org/observations/40206596,Ben Zerante,Invertebrates,
 2434982,Leopardus pardalis,17684,Ocelot,,,,,Terrestrial mammals,LC
 5962163,Maccullochella mariensis,16113,Mary River Cod,,,,,Bony fish,EN
-5229359,Puffinus tenuirostris,15795,Short-tailed Shearwater,,,,,Birds,LC
+5229359,Puffinus tenuirostris,15795,Short-tailed Shearwater,,https://inaturalist-open-data.s3.amazonaws.com/photos/136828700/medium.jpeg,https://www.inaturalist.org/observations/83236445,Miguel A. Casado,Birds,LC
 2418003,Carcharhinus albimarginatus,14901,Silvertip Shark,,,,,Sharks & Rays,VU
 2417940,Prionace glauca,14894,Blue Shark,,https://inaturalist-open-data.s3.amazonaws.com/photos/220488434/medium.jpeg,https://www.inaturalist.org/observations/129721590,Frederico Almada,Sharks & Rays,NT
 2420694,Carcharodon carcharias,14516,Great White Shark,,https://inaturalist-open-data.s3.amazonaws.com/photos/10571121/medium.jpg,https://www.inaturalist.org/observations/7991617,stephencoutts,Sharks & Rays,VU
 5215567,Glyphis glyphis,14409,Speartooth Shark,,,,,Sharks & Rays,VU
 1010610,Limulus polyphemus,14401,Atlantic Horseshoe Crab,,https://inaturalist-open-data.s3.amazonaws.com/photos/173778952/medium.jpg,https://www.inaturalist.org/observations/103781676,Rigel Nava,Invertebrates,VU
 2381337,Kyphosus vaigiensis,13968,Brassy Drummer,,,,,Bony fish,LC
-2481383,Phoebastria nigripes,13580,Black-footed Albatross,,,,,Birds,NT
+2481383,Phoebastria nigripes,13580,Black-footed Albatross,,https://inaturalist-open-data.s3.amazonaws.com/photos/62843720/medium.jpg,https://www.inaturalist.org/observations/39601433,Robin Gwen Agarwal,Birds,NT
 2433475,Arctocephalus pusillus,12664,Brown Fur Seal,,,,,Marine mammals,LC
 5201404,Platycephalus fuscus,12518,Dusky Flathead,,,,,Bony fish,
-2498350,Somateria spectabilis,11666,King Eider,,,,,Birds,LC
+2498350,Somateria spectabilis,11666,King Eider,,https://inaturalist-open-data.s3.amazonaws.com/photos/475565250/medium.jpeg,https://www.inaturalist.org/observations/264818360,Vasily Kalinichenko,Birds,LC
 2418028,Carcharhinus amboinensis,11338,Pigeye Shark,,,,,Sharks & Rays,VU
 2289202,Nautilus pompilius,10943,Emperor Nautilus,,,,,Invertebrates,
 2434810,Histriophoca fasciata,10849,Ribbon Seal,,https://inaturalist-open-data.s3.amazonaws.com/photos/11319079/medium.jpeg,https://www.inaturalist.org/observations/8486729,,Marine mammals,LC
@@ -123,7 +123,7 @@ speciesKey,species,occurrenceCount,vernacularNameEn,vernacularNameEs,imageSrc,im
 2441266,Neoceratodus forsteri,6258,Australian Lungfish,,,,,Bony fish,EN
 2420600,Notorynchus cepedianus,6106,Broadnose Sevengill Shark,,https://inaturalist-open-data.s3.amazonaws.com/photos/15570417/medium.jpg,https://www.inaturalist.org/observations/11036668,rowanwattpringle,Sharks & Rays,VU
 2418771,Paragaleus pectoralis,6097,Atlantic Weasel Shark,,https://inaturalist-open-data.s3.amazonaws.com/photos/304095379/medium.jpeg,https://www.inaturalist.org/observations/175001093,,Sharks & Rays,EN
-2481418,Pelecanoides urinatrix,6093,Common Diving Petrel,,,,,Birds,LC
+2481418,Pelecanoides urinatrix,6093,Common Diving Petrel,,https://inaturalist-open-data.s3.amazonaws.com/photos/461796328/medium.jpeg,https://www.inaturalist.org/observations/257430741,ou.wildlife,Birds,LC
 2440669,Phocoena phocoena,5933,Harbour Porpoise,,,,,Marine mammals,LC
 2440440,Pseudorca crassidens,5774,False Killer Whale,,https://inaturalist-open-data.s3.amazonaws.com/photos/167153562/medium.jpg,https://www.inaturalist.org/observations/100173317,fernando_elorriaga,Marine mammals,NT
 2391729,Rachycentron canadum,5639,Cobia,,https://inaturalist-open-data.s3.amazonaws.com/photos/529527003/medium.jpg,https://www.inaturalist.org/observations/294201524,,Bony fish,LC
@@ -151,7 +151,7 @@ speciesKey,species,occurrenceCount,vernacularNameEn,vernacularNameEs,imageSrc,im
 2417860,Rhizoprionodon taylori,3836,Australian Sharpnose Shark,,,,,Sharks & Rays,LC
 9619349,Pastinachus ater,3803,Broad Cowtail Stingray,,,,,Sharks & Rays,VU
 2497295,Asio flammeus,3784,Short-eared Owl,,https://inaturalist-open-data.s3.amazonaws.com/photos/344405593/medium.jpg,https://www.inaturalist.org/observations/195724174,pkondrashov,Birds,LC
-5229230,Sterna paradisaea,3463,Arctic Tern,,,,,Birds,LC
+5229230,Sterna paradisaea,3463,Arctic Tern,,https://inaturalist-open-data.s3.amazonaws.com/photos/344300361/medium.jpg,https://www.inaturalist.org/observations/195679642,Blake Ross,Birds,LC
 2225646,Callinectes sapidus,3346,Atlantic Blue Crab,,https://inaturalist-open-data.s3.amazonaws.com/photos/226510112/medium.jpg,https://www.inaturalist.org/observations/133016863,chantel_pence,Invertebrates,
 2351209,Coregonus huntsmani,3310,Atlantic Whitefish,,https://inaturalist-open-data.s3.amazonaws.com/photos/29564925/medium.jpeg,https://www.inaturalist.org/observations/19243337,Ian Manning,Bony fish,CR
 8123917,Physeter macrocephalus,3166,Sperm Whale,,,,,Marine mammals,VU
@@ -177,7 +177,7 @@ speciesKey,species,occurrenceCount,vernacularNameEn,vernacularNameEs,imageSrc,im
 5215810,Taeniura lymma,1520,Bluespotted Fantail Ray,,,,,Sharks & Rays,LC
 2418039,Carcharhinus cautus,1502,Nervous Shark,,,,,Sharks & Rays,LC
 2420766,Carcharias taurus,1336,Sand Tiger Shark,,,,,Sharks & Rays,CR
-2481746,Calidris ruficollis,1288,Red-necked Stint,,,,,Birds,NT
+2481746,Calidris ruficollis,1288,Red-necked Stint,,https://inaturalist-open-data.s3.amazonaws.com/photos/209826148/medium.jpg,https://www.inaturalist.org/observations/123832758,Cameron Eckert,Birds,NT
 2400328,Protonibea diacanthus,1275,Black-spotted Croaker,,,,,Bony fish,NT
 2384936,Lutjanus johnii,1268,Golden Snapper,,,,,Bony fish,LC
 2388150,Epinephelus multinotatus,1265,Rankin Cod,,,,,Bony fish,LC

--- a/_layouts/species.html
+++ b/_layouts/species.html
@@ -65,13 +65,15 @@ composition:
         {% assign vernacularName = taxon[vernacularNameColumn] | default: taxon.vernacularNameEn %}
         {% assign preTitle = taxon.species %}
         {% assign title = vernacularName | append: iucnLabel %}
-        {% assign href = taxon.speciesKey | prepend: './occurrence/search?view=map&taxonKey=' %}
+        {% assign dashboardHash = 'W1t7ImlkIjoicDhlcW4iLCJwIjp7fSwidHJhbnNsYXRpb24iOiJzZWFyY2gudGFicy5tYXAiLCJyIjp0cnVlLCJ0IjoibWFwIn1dLFt7ImlkIjoid2JoaHEiLCJwIjp7fSwidCI6ImRhdGFzZXRLZXkifSx7ImlkIjoiM3JkNmkiLCJwIjp7InZpZXciOiJUQUJMRSJ9LCJ0cmFuc2xhdGlvbiI6ImRhc2hib2FyZC5vcmdhbmlzbUlkIiwidCI6Im9yZ2FuaXNtSWQifV1d' %}
+        {% assign href = './occurrence/search?view=dashboard&taxonKey=' | append: taxon.speciesKey | append: '&layout=' | append: dashboardHash %}
         {% assign background = taxon.imageSrc | default: '/assets/species/default.png' | relative_url %}
         {% if taxon.imageBy %}
           {% assign imageLicense = 'Image by [' | append: taxon.imageBy | append: '](' | append: taxon.imageUrl | append: ')' %}
         {% else %}
           {% assign imageLicense = false %}
         {%endif %}
+
         {% include blocks/parts/feature.html
           content=taxon
           preTitle=preTitle


### PR DESCRIPTION
Clicking on a species now shows a dashboard:

<img width="2450" height="1384" alt="Occurrence-search-06-19-2026_05_45_PM" src="https://github.com/user-attachments/assets/103e8114-dcce-412e-a9cf-2b89cd9dbf33" />

This is useful, since you:

- Immediately know what datasets contribute
- Can click on a dataset (link) to show the metadata (so no need for #29)
- You also have an overview of how many organisms were tagged
- You can click on an organism to just see its data

This PR also includes images for all birds.